### PR TITLE
Refactor FileItem component to use Tooltip for full name

### DIFF
--- a/src/ui/components/FileItem.jsx
+++ b/src/ui/components/FileItem.jsx
@@ -5,7 +5,9 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Tooltip from '@mui/material/Tooltip';
 import PropTypes from "prop-types";
+import { basename } from "../utils";
 
 export function FileItem({
   name,
@@ -101,17 +103,19 @@ export function FileItem({
       <IconButton onClick={toggleVisibility}>
         {!visible ? <VisibilityOffIcon /> : <VisibilityIcon />}
       </IconButton>
-      <Typography
-        sx={{
-          marginLeft: '8px',
-          wordBreak: 'break-word', // wrap long names
-          flexBasis: '75%' // allow for name wrapping for long names and alignment to the button
-        }}
-        onClick={toggleActive}
-        onContextMenu={handleContextMenu}
-      >
-        {name}
-      </Typography>
+      <Tooltip title={name}>
+        <Typography
+          sx={{
+            marginLeft: '8px',
+            wordBreak: 'break-word', // wrap long names
+            flexBasis: '75%' // allow for name wrapping for long names and alignment to the button
+          }}
+          onClick={toggleActive}
+          onContextMenu={handleContextMenu}
+        >
+          {basename(name)}
+        </Typography>
+      </Tooltip>
       {/* very small Typography to indicate if mesh or volume */}
       {/* "mesh" or "volume" will be placed in the bottom right corner */}
       <Typography

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -1,0 +1,10 @@
+/**
+ * get the base name of a path
+ * @param {string} path
+ * @returns {string}
+ * @example
+ * basename('/path/to/file.txt') // 'file.txt'
+ */
+export function basename(path) {
+    return path.split('/').pop();
+}


### PR DESCRIPTION
This PR updates the UI to only show the basename of files. Users can hover their mouse over the name in the file list to see a tooltip containing the full file path. 

closes #15 

### screenshot

<img width="990" alt="image" src="https://github.com/niivue/desktop/assets/5217720/38044c39-b279-4e5d-9dbc-77f0b199b16c">
