### PR TITLE
Add help menu with link to GitHub issues

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -911,6 +911,19 @@ let menu = [
         }
       }
     ]
+  },
+  // add help menu with link to github issues
+  {
+    label: 'Help',
+    submenu: [
+      {
+        label: 'Report issue',
+        click: async () => {
+          const { shell } = require('electron');
+          await shell.openExternal('https://github.com/niivue/desktop/issues/new/choose');
+        }
+      }
+    ]
   }
 ];
 // Add macOS application menus


### PR DESCRIPTION
This PR adds the Help menu to the application menu bar and contains the "report issue" menu item. Clicking the "report issue" menu item opens the user's default browser to a new github issue is this repo. 

closes #22 

### screenshot

<img width="989" alt="image" src="https://github.com/niivue/desktop/assets/5217720/c7eebe2e-5879-4feb-b3ff-be5b95a48944">
