### PR TITLE
Features and Fixes: add drag and drop, and fix colormap widget getting out of sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,11 @@
         "cors": "^2.8.5",
         "electron-squirrel-startup": "^1.0.0",
         "express": "^4.18.2",
+        "immutability-helper": "^3.1.1",
         "minimist": "^1.2.8",
-        "react-color": "^2.19.3"
+        "react-color": "^2.19.3",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1"
       },
       "devDependencies": {
         "@electron-forge/cli": "^6.1.1",
@@ -506,7 +509,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2485,6 +2487,21 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
@@ -2590,7 +2607,7 @@
       "version": "18.17.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.14.tgz",
       "integrity": "sha512-ZE/5aB73CyGqgQULkLG87N9GnyGe5TcQjv34pwS8tfBs1IkCh0ASM69mydb2znqd6v0eX+9Ytvk6oQRqu8T1Vw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2602,13 +2619,13 @@
       "version": "15.7.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
       "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
       "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2646,7 +2663,7 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -3843,7 +3860,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/daikon": {
       "version": "1.2.45",
@@ -4014,6 +4031,16 @@
       "dependencies": {
         "buffer-equal": "^1.0.0",
         "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
       }
     },
     "node_modules/doctrine": {
@@ -5188,8 +5215,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5945,7 +5971,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -6077,6 +6102,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutability-helper": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+      "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -8296,6 +8326,43 @@
         "react": "*"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -8467,6 +8534,14 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -8490,8 +8565,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "cors": "^2.8.5",
     "electron-squirrel-startup": "^1.0.0",
     "express": "^4.18.2",
+    "immutability-helper": "^3.1.1",
     "minimist": "^1.2.8",
-    "react-color": "^2.19.3"
+    "react-color": "^2.19.3",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "devDependencies": {
     "@electron-forge/cli": "^6.1.1",

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -120,6 +120,7 @@ function App() {
     (colormap) => {
       nv.volumes[activeImage].colormap = colormap;
       nv.updateGLVolume();
+      setColormap(colormap);
     },
     [activeImage, nv]
   );
@@ -307,7 +308,7 @@ function App() {
     return `http://${commsInfo.host}:${commsInfo.fileServerPort}/${commsInfo.route}?${commsInfo.queryKey}=${path}`;
   }
 
-  function toggleActive(name, value) {
+  const toggleActive = useCallback((name, value) => {
     console.log(name, value);
     let newImages = images.map((image, index) => {
       if (image.name === name) {
@@ -319,7 +320,7 @@ function App() {
       return image;
     });
     setImages(newImages);
-  }
+  }, [images, setActiveImage]);
 
   function handleDrop() {
     let volumes = nv.volumes;
@@ -502,7 +503,13 @@ function App() {
     )
     // update the volume order in Niivue
     nv.setVolume(nv.volumes[dragIndex], hoverIndex)
-  }, [nv])
+    // update the active image if it was moved
+    if (activeImage === dragIndex) {
+      setActiveImage(hoverIndex)
+    } else if (activeImage === hoverIndex) {
+      setActiveImage(dragIndex)
+    }
+  }, [nv, activeImage, setImages, setActiveImage])
 
   const renderImage = useCallback((image, index) => {
     return (
@@ -562,7 +569,7 @@ function App() {
             <ColormapSelect
               colormaps={colormaps} // array of colormap objects
               onSetColormap={updateColormap} // callback to set the colormap of the active image
-              colormap={colormap} // the current colormap of the active image
+              colormap={images.length > 0 ? nv.volumes[activeImage].colormap : colormap} // the current colormap of the active image
             />
             {/* min max input: set the min and max of the active image */}
             <MinMaxInput

--- a/src/ui/components/ColormapSelect.jsx
+++ b/src/ui/components/ColormapSelect.jsx
@@ -12,11 +12,11 @@ export function ColormapSelect({
   ...props
 }) {
 
-  const [color, setColor] = React.useState(colormap)
+  // const [color, setColor] = React.useState(colormap)
 
   function handleColorChange(event) {
     let clr = event.target.value
-    setColor(clr)
+    // setColor(clr)
     onSetColormap(clr)
   }
 
@@ -88,7 +88,7 @@ export function ColormapSelect({
       <Select
         labelId="colormap-select-label"
         sx={{ width: '100%' }}
-        value={color}
+        value={colormap}
         label='Colormap'
         size='small'
         onChange={handleColorChange}

--- a/src/ui/components/FileList.jsx
+++ b/src/ui/components/FileList.jsx
@@ -1,25 +1,31 @@
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
 export function FileList({ children, ...props }) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        minWidth: '100%',
-        width: '100%',
-        minHeight: '40%',
-        // very light gray
-        backgroundColor: '#F8F8F8',
-        // slight border radius
-        borderRadius: '4px',
-        // overflow: 'hidden',
-        overflowY: 'scroll',
-        ...props
-      }}
-    >
-      {children}
-    </Box>
+    <DndProvider backend={HTML5Backend}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          minWidth: '100%',
+          width: '100%',
+          minHeight: '40%',
+          // very light gray
+          backgroundColor: '#F8F8F8',
+          // slight border radius
+          borderRadius: '4px',
+          // overflow: 'hidden',
+          overflowY: 'scroll',
+          ...props
+        }}
+      >
+        {children}
+      </Box>
+
+    </DndProvider>
   )
 }
 


### PR DESCRIPTION
This PR closes #13 and closes #14.

## Features

- add drag and drop support for reordering images (`FileItems`)
- during a drag event, the Niivue scene is updated automatically when the hover index is different from the drag index. This allows users to drag and hover to see scene updates without completing the drop.

## fixes

- The colormap select component could get out of sync with the color of the active image. This has been fixed
- When implementing drag and drop file sorting, the active image was not updated properly. This has been solved too. 

### screenshot

<img width="1222" alt="Screenshot 2024-05-18 at 09 47 29" src="https://github.com/niivue/desktop/assets/5217720/77161a3f-5536-4343-b9ae-7eca164db4f9">

