### PR TITLE
add niivue-vscode as desktop alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Download the latest release from the [releases page](https://github.com/niivue/d
 
 ## Similar projects and alternatives
 
+- [NiiVue web app](https://niivue.github.io/niivue-vscode/) (identical to [niivue-vscode](https://marketplace.visualstudio.com/items?itemName=KorbinianEckstein.niivue), can be installed as desktop app via Chrome)
 - [3D Slicer](https://www.slicer.org/)
 - [ITK-SNAP](http://www.itksnap.org/pmwiki/pmwiki.php)
 - [FSLeyes](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FSLeyes)


### PR DESCRIPTION
This pull request adds a link to niivue-vscode in the similar projects section
niivue-vscode is a progressive web app that runs as extension in vscode, and it can also be accessed as static web page in the browser. On chromium browsers it can be installed as a local app with file associations, behaving like a normal desktop app